### PR TITLE
Kubernetes-2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1319,4 +1319,33 @@ untrusted                             1/1     Running   0          24m   10.200.
 - Добавлены права для сервисного аккаунта `kubectl create clusterrolebinding kubernetes-dashboard  --clusterrole=cluster-admin --serviceaccount=kube-system:kubernetes-dashboard`
 - Залогинился с токеном из `kubectl config view`
 
+### HW26: Задание со *
+
+- Подготовил сценарий создания кластера при помощи terraform согласно рекомендациям.
+- Получил манифест для добавления прав доступа на kubernetes dashboard `kubectl create clusterrolebinding kubernetes-dashboard --clusterrole=cluster-admin --serviceaccount=kube-system:kubernetes-dashboard -o yaml --dry-run`
+
+<details>
+  <summary>dashboard manifest</summary>
+
+```bash
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: kubernetes-dashboard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: kubernetes-dashboard
+  namespace: kube-system
+```
+
+</details>
+
+
+
+
 </details>

--- a/kubernetes/reddit/comment-deployment.yml
+++ b/kubernetes/reddit/comment-deployment.yml
@@ -2,18 +2,26 @@
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
-  name: comment-deployment
+  name: comment
+  labels:
+    app: reddit
+    component: comment
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
-      app: comment
+      app: reddit
+      component: comment
   template:
     metadata:
       name: comment
       labels:
-        app: comment
+        app: reddit
+        component: comment
     spec:
       containers:
       - image: darkarren/comment
         name: comment
+        env:
+        - name: COMMENT_DATABASE_HOST
+          value: comment-db

--- a/kubernetes/reddit/comment-mongodb-service.yml
+++ b/kubernetes/reddit/comment-mongodb-service.yml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: comment-db
+  labels:
+    app: reddit
+    component: mongo
+    comment-db: "true"
+spec:
+  ports:
+  - port: 27017
+    protocol: TCP
+    targetPort: 27017
+  selector:
+    app: reddit
+    component: mongo
+    comment-db: "true"

--- a/kubernetes/reddit/comment-service.yml
+++ b/kubernetes/reddit/comment-service.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: comment
+  labels:
+    app: reddit
+    component: comment
+spec:
+  ports:
+  - port: 9292
+    protocol: TCP
+    targetPort: 9292
+  selector:
+    app: reddit
+    component: comment

--- a/kubernetes/reddit/dev-namespace.yml
+++ b/kubernetes/reddit/dev-namespace.yml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dev

--- a/kubernetes/reddit/mongo-deployment.yml
+++ b/kubernetes/reddit/mongo-deployment.yml
@@ -2,18 +2,33 @@
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
-  name: mongo-deployment
+  name: mongo
+  labels:
+    app: reddit
+    component: mongo
+    comment-db: "true"
+    post-db: "true"
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: mongo
+      app: reddit
+      component: mongo
   template:
     metadata:
       name: mongo
       labels:
-        app: mongo
+        app: reddit
+        component: mongo
+        comment-db: "true"
+        post-db: "true"
     spec:
       containers:
-      - image: mongo
+      - image: mongo:3.2
         name: mongo
+        volumeMounts:
+        - name: mongo-persistent-storage
+          mountPath: /data/db
+      volumes:
+      - name: mongo-persistent-storage
+        emptyDir: {}

--- a/kubernetes/reddit/mongodb-service.yml
+++ b/kubernetes/reddit/mongodb-service.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongodb
+  labels:
+    app: reddit
+    component: mongo
+spec:
+  ports:
+  - port: 27017
+    protocol: TCP
+    targetPort: 27017
+  selector:
+    app: reddit
+    component: mongo

--- a/kubernetes/reddit/post-deployment.yml
+++ b/kubernetes/reddit/post-deployment.yml
@@ -2,18 +2,26 @@
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
-  name: post-deployment
+  name: post
+  labels:
+    app: reddit
+    component: post
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
-      app: post
+      app: reddit
+      component: post
   template:
     metadata:
       name: post
       labels:
-        app: post
+        app: reddit
+        component: post
     spec:
       containers:
       - image: darkarren/post
         name: post
+        env:
+        - name: POST_DATABASE_HOST
+          value: post-db

--- a/kubernetes/reddit/post-mongodb-service.yml
+++ b/kubernetes/reddit/post-mongodb-service.yml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: post-db
+  labels:
+    app: reddit
+    component: mongo
+    post-db: "true"
+spec:
+  ports:
+  - port: 27017
+    protocol: TCP
+    targetPort: 27017
+  selector:
+    app: reddit
+    component: mongo
+    post-db: "true"

--- a/kubernetes/reddit/post-service.yml
+++ b/kubernetes/reddit/post-service.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: post
+  labels:
+    app: reddit
+    component: post
+spec:
+  ports:
+  - port: 5000
+    protocol: TCP
+    targetPort: 5000
+  selector:
+    app: reddit
+    component: post

--- a/kubernetes/reddit/ui-deployment.yml
+++ b/kubernetes/reddit/ui-deployment.yml
@@ -2,18 +2,28 @@
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
-  name: ui-deployment
+  name: ui
+  labels:
+    app: reddit
+    component: ui
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
-      app: ui
+      app: reddit
+      component: ui
   template:
     metadata:
-      name: ui
+      name: ui-pod
       labels:
-        app: ui
+        app: reddit
+        component: ui
     spec:
       containers:
       - image: darkarren/ui
         name: ui
+        env:
+        - name: ENV
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace

--- a/kubernetes/reddit/ui-service.yml
+++ b/kubernetes/reddit/ui-service.yml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ui
+  labels:
+    app: reddit
+    component: ui
+spec:
+  type: NodePort
+  ports:
+  - port: 9292
+    protocol: TCP
+    targetPort: 9292
+  selector:
+    app: reddit
+    component: ui

--- a/kubernetes/terraform/main.tf
+++ b/kubernetes/terraform/main.tf
@@ -1,0 +1,75 @@
+provider "google" {
+  version = "2.0.0"
+  project = "${var.project}"
+  region  = "${var.region}"
+}
+
+resource "google_container_cluster" "primary" {
+  name               = "${var.gke_cluster_name}"
+  zone               = "${var.zone}"
+  remove_default_node_pool = true
+  initial_node_count = 1
+
+  # Setting an empty username and password explicitly disables basic auth
+  master_auth {
+    username = ""
+    password = ""
+    client_certificate_config {
+      issue_client_certificate = false
+    }
+  }
+
+  addons_config {
+    http_load_balancing {
+      disabled = false
+    }
+    horizontal_pod_autoscaling {
+      disabled = false
+    }
+    kubernetes_dashboard {
+      disabled = false
+    }
+  }
+
+  timeouts {
+    create = "15m"
+    update = "30m"
+  }
+
+  provisioner "local-exec" {
+    command = "gcloud container clusters get-credentials ${var.gke_cluster_name} --zone ${var.zone} --project ${var.project} && kubectl apply -f ../reddit/dev-namespace.yml && kubectl apply -f ../reddit/ -n dev && kubectl create clusterrolebinding kubernetes-dashboard  --clusterrole=cluster-admin --serviceaccount=kube-system:kubernetes-dashboard"
+  }
+
+}
+
+resource "google_container_node_pool" "primary_preemptible_nodes" {
+  name       = "reddit-node-pool"
+  zone   = "${var.zone}"
+  cluster    = "${google_container_cluster.primary.name}"
+  node_count = "${var.gke_node_count}"
+
+  node_config {
+    preemptible  = true
+    disk_size_gb = "${var.gke_node_disk_size}"
+    disk_type = "${var.gke_node_disk_type}"
+    image_type = "${var.gke_node_image_type}"
+    machine_type = "${var.gke_node_machine_type}"
+    metadata = {
+      disable-legacy-endpoints = "true"
+    }
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/compute",
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/servicecontrol",
+      "https://www.googleapis.com/auth/service.management.readonly",
+      "https://www.googleapis.com/auth/trace.append"
+    ]
+  }
+}
+
+module "vpc" {
+  source        = "./modules/vpc"
+  source_ranges = "${var.source_ranges}"
+}

--- a/kubernetes/terraform/modules/vpc/main.tf
+++ b/kubernetes/terraform/modules/vpc/main.tf
@@ -1,0 +1,12 @@
+resource "google_compute_firewall" "firewall_kubernetes" {
+  name        = "default-allow-kubernetes-node-ports"
+  network     = "default"
+  description = "Allow kubernetes from anywhere"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["30000-32767"]
+  }
+
+  source_ranges = "${var.source_ranges}"
+}

--- a/kubernetes/terraform/modules/vpc/variables.tf
+++ b/kubernetes/terraform/modules/vpc/variables.tf
@@ -1,0 +1,4 @@
+variable source_ranges {
+  description = "Allowed IP addresses"
+  default     = ["0.0.0.0/0"]
+}

--- a/kubernetes/terraform/outputs.tf
+++ b/kubernetes/terraform/outputs.tf
@@ -1,0 +1,13 @@
+# The following outputs allow authentication and connectivity to the GKE Cluster
+# by using certificate-based authentication.
+#output "client_certificate" {
+#  value = "${google_container_cluster.primary.master_auth.0.client_certificate}"
+#}
+
+#output "client_key" {
+#  value = "${google_container_cluster.primary.master_auth.0.client_key}"
+#}
+
+#output "cluster_ca_certificate" {
+#  value = "${google_container_cluster.primary.master_auth.0.cluster_ca_certificate}"
+#}

--- a/kubernetes/terraform/terraform.tfvars.example
+++ b/kubernetes/terraform/terraform.tfvars.example
@@ -1,0 +1,1 @@
+project = "docker-123456"

--- a/kubernetes/terraform/variables.tf
+++ b/kubernetes/terraform/variables.tf
@@ -1,0 +1,53 @@
+variable project {
+  description = "Project ID"
+}
+
+variable region {
+  description = "Region"
+  default     = "europe-west3"
+}
+
+variable zone {
+  description = "Zone"
+  default     = "europe-west3-b"
+}
+
+variable source_ranges {
+  description = "Allowed IP addresses"
+  default     = ["0.0.0.0/0"]
+}
+
+variable gke_cluster_name {
+  description = "name of the cluster gke"
+  default     = "reddit-gke"
+}
+
+variable gke_node_count {
+  description = "GKE node count"
+  default     = "2"
+}
+
+variable gke_cluster_version {
+  description = "GKE cluster version"
+  default     = "1.13.7-gke.8"
+}
+
+variable gke_node_machine_type {
+  description = "GKE machine type"
+  default     = "g1-small"
+}
+
+variable gke_node_image_type {
+  description = "GKE Image type"
+  default     = "COS"
+}
+
+variable gke_node_disk_type {
+  description = "GKE node disk type"
+  default     = "pd-standard"
+}
+
+variable gke_node_disk_size {
+  description = "GKE Disk size"
+  default     = "20"
+}


### PR DESCRIPTION
# Выполнено ДЗ №26

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
- Установлен kubectl и minikube
- Запущен minikube кластер

### Deployment

- Подготовлен deployment и запущен компонент UI, проверено через port-forwarding
- Подготовлен deployment и запущен компонент Comment, проверено через port-forwarding
- По аналогии с UI и Comment подготовлен deployment и запущен компонент Post, проверено через port-forwarding
- Подготовлен deployment для MongoDB, добавлено монтирование Volume, MongoDB запущен

### Services

- Добавлен и запущен service для компонента Comment, проверено наличие Endpoints для подов
- Добавлен и запущен service для компонента Post, проверено наличие Endpoints для подов
- Добавлен и запущен service для mongodb
- Добавлен service для comment_db с лейблом `comment_db: "true"`
- В mongo-deployment.yml так же добавлен лейбл `comment_db: "true"` в метадату деплоймента и в метадату пода
- Для подов comment добавлена переменная окружений `COMMENT_DATABASE_HOST: comment_db`
- По аналогии с comment_db добавлен сервис, лейблы и переменная окружения для post_db
- Проверил логи, убедился что обращение идет к нужным базам
- Удалил объект mongodb service
- Для обеспечения доступа к UI добавлен сервис ui-service.yml с типом NodePort
- В ui-service.yml добавлен параметр `nodePort: 32092`

### Minikube

- Через Minikube получена главная страница компонента UI, список сервисов, список аддонов, список запущенных подов в неймспейсе default, объекты для аддона dashboard из неймспейса kube-system

### Dashboard

- Запущен дашборд `minikube dashboard`
- Изучен функционал

### Namespace

- Добавлено описание для создания отдельного неймспейса для среды разработки dev
- Приложение запущено в новом неймспейса
- В deployment для компонента UI добавлена информация об окружениях, в которых будет запускаться контейнеры
- Убедился, что теперь в заголовке страницы корректно отображается навзание окружения `Microservices Reddit in dev ui-ff5c4db7f-6b2kl container
`

### Google Kubernetes Engine

- Запущено создание кластера Kubernetes через web-консоль Google Cloud
- Подготовлен контекст для подключения к кластеру `gcloud container clusters get-credentials your-first-cluster-1 --zone europe-west3-b --project docker-123456`
- Создан dev namespace и задеплоено приложение
- В VPC Networks добавлено правило разрешающее доступ по портам 30000-32767
- Получены внешние адреса нод кластера `kubectl get nodes -o wide`
- Получен порт публикации сервиса ui `kubectl describe service ui -n dev | grep NodePort`
- Убедился, что сервис доступен по адресу `http://<node-ip>:<NodePort>`

<details>
  <summary>proofpic</summary>

![reddit](https://www.dropbox.com/s/mnxb6wjk1xqpdzf/reddit_gke.png?raw=1)

</details>

- Для кластера в GKE включен Dashboard (Cluster - Edit - Addons - Dashboard)
- Запустил kubectl proxy, ui доступен <http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/#!/login>
- Добавлены права для сервисного аккаунта `kubectl create clusterrolebinding kubernetes-dashboard  --clusterrole=cluster-admin --serviceaccount=kube-system:kubernetes-dashboard`
- Залогинился с токеном из `kubectl config view`

### HW26: Задание со *

- Подготовил сценарий создания кластера при помощи terraform согласно рекомендациям.
- Получил манифест для добавления прав доступа на kubernetes dashboard `kubectl create clusterrolebinding kubernetes-dashboard --clusterrole=cluster-admin --serviceaccount=kube-system:kubernetes-dashboard -o yaml --dry-run`

<details>
  <summary>dashboard manifest</summary>

```bash
apiVersion: rbac.authorization.k8s.io/v1beta1
kind: ClusterRoleBinding
metadata:
  creationTimestamp: null
  name: kubernetes-dashboard
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: cluster-admin
subjects:
- kind: ServiceAccount
  name: kubernetes-dashboard
  namespace: kube-system
```

</details>

## Как запустить проект:
- Перейти в директорию kubernetes/terraform
- Скопировать terraform.tfvars.example в terraform.tfvars и указать project.
- Выполнить `terraform get && terraform init && terraform apply -auto-approve=true`, для развёртывания кластера
- Выполнить `kubectl get nodes -o wide && kubectl describe service ui -n dev | grep NodePort`, чтобы получить ip нод и порт сервиса ui
- Выполнить `kubectl proxy` для получения доступа к dashboard

## Как проверить работоспособность:
- Перейти по ссылке <http://node_ip:ui_port>
- После запуска `kubectl proxy` открыть в браузере <http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/#!/overview?namespace=dev>, авторизоваться при помощи токена сервисного пользователя из `kubectl config view`

## PR checklist
 - [x] Выставил label с номером домашнего задания
 - [x] Выставил label с темой домашнего задания